### PR TITLE
Add training options and ignore generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore trained models and datasets
+*.joblib
+run.log


### PR DESCRIPTION
## Summary
- add `skip_grid_search` and `max_samples` options for faster training
- ignore generated artifacts via `.gitignore`

## Testing
- `python ml.py --skip-grid-search --max-samples 1000 --model-path elliott_model.joblib --dataset-path elliott_dataset.joblib > run.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68407461accc8326896a406814af3fc6