### PR TITLE
Handle missing ML features

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1326,8 +1326,10 @@ def run_ml_on_bitget(model, features, importance, symbol=SYMBOL, interval="1H", 
 
     # Sicherstellen, dass alle vom Modell erwarteten Features vorhanden sind
     missing = [f for f in features if f not in df_features.columns]
-    for m in missing:
-        df_features[m] = 0.0
+    if missing:
+        msg = "Fehlende Features für Vorhersage: " + ", ".join(missing)
+        print(red(msg))
+        raise ValueError(msg)
 
     pred_raw = model.predict(df_features[features])
     pred = smooth_predictions(pred_raw)
@@ -1546,8 +1548,18 @@ def main():
                                                max_samples=args.max_samples,
                                                model_type=args.model,
                                                feature_selection=args.feature_selection)
-    run_ml_on_bitget(model, features, importance, symbol=SYMBOL, interval="1H", livedata_len=LIVEDATA_LEN,
-                     extra_intervals=["2H", "4H", "1D", "1W"])
+    try:
+        run_ml_on_bitget(
+            model,
+            features,
+            importance,
+            symbol=SYMBOL,
+            interval="1H",
+            livedata_len=LIVEDATA_LEN,
+            extra_intervals=["2H", "4H", "1D", "1W"],
+        )
+    except ValueError as e:
+        print(red(str(e)))
 
 if __name__ == "__main__":
     main()

--- a/test_ml.py
+++ b/test_ml.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import numpy as np
+import pytest
+import ml
+
+class DummyModel:
+    def __init__(self):
+        self.classes_ = np.array(['A'])
+    def predict(self, X):
+        return np.array(['A'] * len(X))
+    def predict_proba(self, X):
+        return np.array([[1.0]] * len(X))
+
+
+def test_run_ml_on_bitget_missing_features(monkeypatch):
+    df_stub = pd.DataFrame({
+        'timestamp': pd.date_range('2020-01-01', periods=3, freq='h'),
+        'open': [1.0, 1.0, 1.0],
+        'high': [1.0, 1.0, 1.0],
+        'low': [1.0, 1.0, 1.0],
+        'close': [1.0, 1.0, 1.0],
+        'volume': [1.0, 1.0, 1.0],
+    })
+
+    def fake_fetch(*args, **kwargs):
+        return df_stub
+
+    def fake_make_features(*args, **kwargs):
+        return pd.DataFrame({'foo': [1.0]})
+
+    monkeypatch.setattr(ml, 'fetch_bitget_ohlcv_auto', fake_fetch)
+    monkeypatch.setattr(ml, 'make_features', fake_make_features)
+    monkeypatch.setattr(ml, 'get_all_levels', lambda *a, **k: [])
+    monkeypatch.setattr(ml, 'get_fib_levels', lambda *a, **k: [])
+
+    model = DummyModel()
+    with pytest.raises(ValueError):
+        ml.run_ml_on_bitget(model, ['foo', 'bar'], None)


### PR DESCRIPTION
## Summary
- abort prediction when required features are missing in `run_ml_on_bitget`
- show the warning at the caller
- test that missing features raise an error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e58c638c8326a0b2947ad79a6d6c