### PR TITLE
Fix unused variable in compute_wave_fibs

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -643,7 +643,6 @@ def compute_wave_fibs(df, label_col='wave_pred', buffer=PUFFER):
     if label_col not in df.columns:
         return df
 
-    fib_ratios = [0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0, 1.618, 2.618]
 
     df = df.copy()
     df['wave_fib_dist'] = np.nan


### PR DESCRIPTION
## Summary
- remove an unused `fib_ratios` variable from `compute_wave_fibs`

## Testing
- `pyflakes *.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lightgbm')*

------
https://chatgpt.com/codex/tasks/task_e_6847e902dc9c83268ebb440332a7fcf8