### PR TITLE
Add pattern registry for synthetic generators

### DIFF
--- a/pattern_registry.py
+++ b/pattern_registry.py
@@ -1,0 +1,44 @@
+from typing import Callable, Iterable, Dict, List, Optional, Tuple
+
+class PatternRegistry:
+    """Registry for synthetic pattern generators."""
+
+    def __init__(self) -> None:
+        self._patterns: Dict[str, Callable[..., object]] = {}
+        self._next_wave: Dict[str, List[str]] = {}
+
+    def register(
+        self,
+        name: str,
+        generator: Callable[..., object],
+        next_wave: Optional[Iterable[str]] = None,
+    ) -> Callable[..., object]:
+        """Register a pattern generator with optional follow-up waves."""
+        self._patterns[name] = generator
+        if next_wave is not None:
+            if isinstance(next_wave, str):
+                self._next_wave[name] = [next_wave]
+            else:
+                self._next_wave[name] = list(next_wave)
+        return generator
+
+    def generators(self) -> List[Tuple[Callable[..., object], str]]:
+        """Return list of registered generators as ``(func, name)`` tuples."""
+        return [(func, name) for name, func in self._patterns.items()]
+
+    def get_next_wave(self, name: str) -> List[str]:
+        """Return configured follow-up waves for ``name``."""
+        return self._next_wave.get(name, [])
+
+
+pattern_registry = PatternRegistry()
+
+
+def register_pattern(name: str, next_wave: Optional[Iterable[str]] = None):
+    """Decorator to register a pattern generator."""
+
+    def decorator(func: Callable[..., object]):
+        pattern_registry.register(name, func, next_wave)
+        return func
+
+    return decorator


### PR DESCRIPTION
## Summary
- implement `pattern_registry` module for registering pattern generators
- register existing synthetic pattern functions using `@register_pattern`
- refactor `generate_rulebased_synthetic_with_patterns` and `get_next_wave` to use the registry
- keep default Elliott next-wave sequence in `DEFAULT_NEXT_WAVE`

## Testing
- `python -m py_compile ml.py pattern_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ea353f9c8326b7f9d1fc03875834