### PR TITLE
Improve dataset generation with validation

### DIFF
--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import ml
+
+
+def test_no_negative_prices():
+    df = ml.generate_rulebased_synthetic_with_patterns(n=50, log=False)
+    assert (df[["open", "high", "low", "close"]] >= 0).all().all()
+
+
+def test_label_distribution():
+    df = ml.generate_rulebased_synthetic_with_patterns(n=50, log=False)
+    counts = df['wave'].value_counts(normalize=True)
+    expected = ["1", "2", "3", "4", "5", "A", "B", "C"]
+    counts = counts[counts.index.isin(expected)]
+    assert not (counts < 0.01).any()


### PR DESCRIPTION
## Summary
- clip negative values when generating synthetic wave segments and negative samples
- add balancing and validation to `generate_rulebased_synthetic_with_patterns`
- include dataset balancing and validation helpers
- add simple pytest suite for data generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684876ebbf108326a957131bda6cf4c7