### PR TITLE
Add balanced wave dataset generation

### DIFF
--- a/tests/test_datagen.py
+++ b/tests/test_datagen.py
@@ -20,3 +20,15 @@ def test_label_distribution():
     expected = ["1", "2", "3", "4", "5", "A", "B", "C"]
     counts = counts[counts.index.isin(expected)]
     assert not (counts < 0.01).any()
+
+
+def test_target_per_label_generation():
+    df = ml.generate_rulebased_synthetic_with_patterns(
+        target_per_label=10,
+        negative_ratio=0.1,
+        pattern_ratio=0.2,
+        log=False,
+    )
+    counts = {lbl: (df["wave"] == lbl).sum() for lbl in ["1", "2", "3", "4", "5", "A", "B", "C"]}
+    for cnt in counts.values():
+        assert cnt >= 10


### PR DESCRIPTION
## Summary
- extend `generate_rulebased_synthetic_with_patterns` to support a target count per label
- implement `generate_balanced_wave_dataset` for balanced data generation
- add test covering new `target_per_label` argument

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684880cfc7f48326a04eb03c0149c3a6