### PR TITLE
Fix Counter logging in dataset generator

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -1002,7 +1002,10 @@ def generate_rulebased_synthetic_with_patterns(
     counts = Counter(combined["wave"].value_counts().to_dict())
     if log:
         print(f"[DataGen] Fertig – Gesamtanzahl Datenpunkte: {len(combined)}")
-        print("[DataGen] Labelverteilung:\n" + counts.to_string())
+        print(
+            "[DataGen] Labelverteilung:\n"
+            + pd.Series(counts).astype(int).to_string()
+        )
 
     expected = main_labels
     missing = [lbl for lbl in expected if counts.get(lbl, 0) < min_count]


### PR DESCRIPTION
## Summary
- fix `counts.to_string()` for Counter objects in `generate_rulebased_synthetic_with_patterns`
- convert Counter to pandas Series when printing label distribution

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848833f2d308326bc3a2750cd794685