### PR TITLE
Fix missing feature error

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -312,8 +312,6 @@ FEATURES_BASE = [
     "fib_near_1d",
     "fib_dist_1w",
     "fib_near_1w",
-    "wave_fib_dist",
-    "wave_fib_near",
 ]
 
 


### PR DESCRIPTION
## Summary
- drop `wave_fib_dist` and `wave_fib_near` from ML feature list
- keep computing these features after prediction for analysis

## Testing
- `python -m py_compile ml.py`
- *(partial run aborted)* `python ml.py --test-mode --skip-grid-search --max-samples 50 --model rf`

------
https://chatgpt.com/codex/tasks/task_e_68494fe8481483269a9b5208a047e8a2