### PR TITLE
Handle missing wave start data in output

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -2425,20 +2425,28 @@ def run_ml_on_bitget(
         f"| Start: {wave_start_price:.4f} | "
         f"Ziel: {target_range[0]:.4f}-{target_range[1]:.4f}"
     )
-    if next_wave and next_target_range:
+    if next_wave and next_target_range and next_wave_start is not None:
         print(
             f"Nächste erwartete Welle: {next_wave} "
             f"({LABEL_MAP.get(next_wave, next_wave)}) "
             f"| Start: {next_wave_start:.4f} | "
             f"Ziel: {next_target_range[0]:.4f}-{next_target_range[1]:.4f}"
         )
-    if next_next_wave and next_next_target_range:
+    elif next_wave:
+        print("Nächste Welle noch nicht erkannt.")
+    if (
+        next_next_wave
+        and next_next_target_range
+        and next_next_wave_start is not None
+    ):
         print(
             f"Darauffolgende erwartete Welle: {next_next_wave} "
             f"({LABEL_MAP.get(next_next_wave, next_next_wave)}) "
             f"| Start: {next_next_wave_start:.4f} | "
             f"Ziel: {next_next_target_range[0]:.4f}-{next_next_target_range[1]:.4f}"
         )
+    elif next_next_wave:
+        print("Übernächste Welle noch nicht erkannt.")
 
     # === Breakout Zone (letzte Patternrange) ===
     idx_pattern = df_features[df_features["wave_pred"] == current_wave].index


### PR DESCRIPTION
## Summary
- avoid formatting None when next wave start data is unavailable
- log message when next or overnext waves aren't recognized

## Testing
- `python -m py_compile ml.py`
- `python ml.py --help` *(fails: ModuleNotFoundError: No module named 'lightgbm')*

------
https://chatgpt.com/codex/tasks/task_e_68495710c75c832691709457dfbf1a0e