### PR TITLE
Fix trade suggestion when target range incomplete

### DIFF
--- a/ml.py
+++ b/ml.py
@@ -2071,8 +2071,16 @@ def suggest_trade(
     """
 
     entry = last_close
-    if target_range is None:
-        print(red("Kein gültiges Kursziel berechnet."))
+    if (
+        target_range is None
+        or len(target_range) != 2
+        or any(t is None for t in target_range)
+    ):
+        print(
+            red(
+                "Kein gültiges Kursziel berechnet (target_range ist None oder enthält None)."
+            )
+        )
         return None, None, None, None
 
     adj_risk = risk * probability if probability is not None else risk


### PR DESCRIPTION
## Summary
- guard against invalid target ranges in `suggest_trade`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495af517b4832697c773d3dcae9566