### PR TITLE
Improve wave freshness check

### DIFF
--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,0 +1,38 @@
+import sys
+import types
+import numpy as np
+import pandas as pd
+import pytest
+
+# Provide a dummy lightgbm module if not available
+if 'lightgbm' not in sys.modules:
+    sys.modules['lightgbm'] = types.ModuleType('lightgbm')
+    sys.modules['lightgbm'].LGBMClassifier = object
+
+from ml import _latest_segment_indices, elliott_target
+
+
+def test_latest_segment_indices_fresh():
+    df = pd.DataFrame({"wave_pred": list("AABBBCCDD")})
+    seg = _latest_segment_indices(df, "B", min_len=2, end_buffer=5)
+    assert np.array_equal(seg, np.array([2, 3, 4]))
+
+
+def test_latest_segment_indices_not_fresh():
+    df = pd.DataFrame({"wave_pred": list("AABBBCCDD")})
+    seg = _latest_segment_indices(df, "B", min_len=4, end_buffer=5)
+    assert seg.size == 0
+
+
+def test_elliott_target_fallback():
+    df = pd.DataFrame({
+        "close": np.arange(10.0),
+        "high": np.arange(10.0),
+        "low": np.arange(10.0),
+        "wave_pred": ["1"] * 3 + ["0"] * 7,
+    })
+    target, start_price, last_close = elliott_target(
+        df, "1", last_complete_close=8.0
+    )
+    assert target[0] == pytest.approx(8.0 * 1.01)
+    assert target[1] == pytest.approx(8.0 * 1.01)


### PR DESCRIPTION
## Summary
- support min length + end buffer in `_latest_segment_indices`
- refresh `pattern_target` and `elliott_target` usage
- handle missing segment in `elliott_target`
- add unit tests for the new logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849602da4a48326ad0bdd3c66290906