### PR TITLE
Add feature statistics logging

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E402,E501,W503


### PR DESCRIPTION
## Summary
- log per-feature statistics with new `log_feature_stats`
- save statistics during training and store alongside the model
- compare live feature stats to training stats when running predictions
- configure flake8

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6849decec1508326a321869c618d672d